### PR TITLE
Allow for arr KeyError

### DIFF
--- a/Tests/test_image_array.py
+++ b/Tests/test_image_array.py
@@ -52,3 +52,8 @@ class TestImageArray(PillowTestCase):
         self.assertEqual(test("RGB"), ("RGB", (128, 100), True))
         self.assertEqual(test("RGBA"), ("RGBA", (128, 100), True))
         self.assertEqual(test("RGBX"), ("RGBA", (128, 100), True))
+
+        # Test mode is None with no "typestr" in the array interface
+        with self.assertRaises(TypeError):
+            wrapped = Wrapper(test("L"), {"shape": (100, 128)})
+            Image.fromarray(wrapped)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -2631,6 +2631,9 @@ def fromarray(obj, mode=None):
     if mode is None:
         try:
             typekey = (1, 1) + shape[2:], arr["typestr"]
+        except KeyError:
+            raise TypeError("Cannot handle this data type")
+        try:
             mode, rawmode = _fromarray_typemap[typekey]
         except KeyError:
             raise TypeError("Cannot handle this data type: %s, %s" % typekey)


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4181

It is, strictly speaking, possible that `arr["typestr"]` might raise a KeyError, which with your change would lead to `UnboundLocalError: local variable 'typekey' referenced before assignment`.

This PR resolves that.